### PR TITLE
Use MSBuild Copy and update Release targets

### DIFF
--- a/LibSass.NET.Tests/LibSass.NET.Tests.csproj
+++ b/LibSass.NET.Tests/LibSass.NET.Tests.csproj
@@ -125,7 +125,7 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass32.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass64.dll" DestinationFolder="$(TargetDir)" />
   </Target>
 </Project>

--- a/LibSass.NET.Tests/LibSass.NET.Tests.csproj
+++ b/LibSass.NET.Tests/LibSass.NET.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -112,22 +113,19 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(SolutionDir)bin\x86\libsass.dll" "$(OutputDir)libsass32.dll"
-copy "$(SolutionDir)bin\x64\libsass.dll" "$(OutputDir)libsass64.dll"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+  </Target>
 </Project>

--- a/LibSass.NET/LibSass.NET.csproj
+++ b/LibSass.NET/LibSass.NET.csproj
@@ -26,8 +26,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>$(SolutionDir)bin\</OutputPath>
-    <IntermediateOutputPath>$(SolutionDir)bin\obj\</IntermediateOutputPath>
+    <OutputPath>$(SolutionDir)bin\Release\</OutputPath>
+    <IntermediateOutputPath>$(SolutionDir)bin\Release\obj\</IntermediateOutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -82,7 +82,7 @@
     <Copy SourceFiles="$(OutDir)x64\libsass.dll" DestinationFiles="$(OutDir)libsass64.dll" />
   </Target>
   <Target Name="BuildLibSass">
-    <MSBuild Targets="Build" Projects="..\LibSass\win\libsass.sln" BuildInParallel="true" Properties="Configuration=$(Configuration);Platform=Win32;OutDir=$(OutDir)x86\" />
-    <MSBuild Targets="Build" Projects="..\LibSass\win\libsass.sln" BuildInParallel="true" Properties="Configuration=$(Configuration);Platform=Win64;OutDir=$(OutDir)x64\" />
+    <MSBuild Targets="Build" Projects="..\LibSass\win\libsass.sln" BuildInParallel="true" Properties="Configuration=$(Configuration);Platform=Win32;OutDir=$(OutDir)x86\;IntDir=$(OutDir)x86\" />
+    <MSBuild Targets="Build" Projects="..\LibSass\win\libsass.sln" BuildInParallel="true" Properties="Configuration=$(Configuration);Platform=Win64;OutDir=$(OutDir)x64\;IntDir=$(OutDir)x64\" />
   </Target>
 </Project>

--- a/LibSass.NET/LibSass.NET.csproj
+++ b/LibSass.NET/LibSass.NET.csproj
@@ -78,8 +78,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Build LibSass -->
   <Target Name="CopyLibSass" DependsOnTargets="BuildLibSass">
-    <Exec Command="copy &quot;$(OutDir)x86\libsass.dll&quot; &quot;$(OutDir)libsass32.dll&quot;" LogStandardErrorAsError="true" ConsoleToMSBuild="true" />
-    <Exec Command="copy &quot;$(OutDir)x64\libsass.dll&quot; &quot;$(OutDir)libsass64.dll&quot;" LogStandardErrorAsError="true" ConsoleToMSBuild="true" />
+    <Copy SourceFiles="$(OutDir)x86\libsass.dll" DestinationFiles="$(OutDir)libsass32.dll" />
+    <Copy SourceFiles="$(OutDir)x64\libsass.dll" DestinationFiles="$(OutDir)libsass64.dll" />
   </Target>
   <Target Name="BuildLibSass">
     <MSBuild Targets="Build" Projects="..\LibSass\win\libsass.sln" BuildInParallel="true" Properties="Configuration=$(Configuration);Platform=Win32;OutDir=$(OutDir)x86\" />

--- a/LibSass.NET/LibSass.Net.nuspec
+++ b/LibSass.NET/LibSass.Net.nuspec
@@ -13,9 +13,9 @@
     <tags>SASS SCSS CSS LibSass</tags>
   </metadata>
   <files>
-    <file src="..\bin\x64\libsass.dll" target="build\libsass64.dll" />
-    <file src="..\bin\x86\libsass.dll" target="build\libsass32.dll" />
+    <file src="..\bin\$configuration$\libsass64.dll" target="build\libsass64.dll" />
+    <file src="..\bin\$configuration$\libsass32.dll" target="build\libsass32.dll" />
     <file src="libsassnet.targets" target="build\libsassnet.targets" />
-    <file src="..\bin\LibSass.NET.dll" target="lib\net40\LibSass.NET.dll" />
+    <file src="..\bin\$configuration$\LibSass.NET.dll" target="lib\net40\LibSass.NET.dll" />
   </files>
 </package>

--- a/contrib/LibSass.NET.Console/LibSass.NET.Console.csproj
+++ b/contrib/LibSass.NET.Console/LibSass.NET.Console.csproj
@@ -54,15 +54,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent Condition="$(Configuration) == 'Debug'">copy "$(SolutionDir)bin\Debug\libsass.dll" "$(OutputDir)libsass.dll"</PostBuildEvent>
-    <PostBuildEvent Condition="$(Configuration) == 'Release'">copy "$(SolutionDir)bin\libsass.dll" "$(OutputDir)libsass.dll"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+  </Target>
 </Project>

--- a/contrib/LibSass.NET.Console/LibSass.NET.Console.csproj
+++ b/contrib/LibSass.NET.Console/LibSass.NET.Console.csproj
@@ -20,7 +20,6 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <IntermediateOutputPath>$(SolutionDir)bin\Debug\obj\</IntermediateOutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,8 +29,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <IntermediateOutputPath>$(SolutionDir)bin\obj\</IntermediateOutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -60,7 +58,7 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass32.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass64.dll" DestinationFolder="$(TargetDir)" />
   </Target>
 </Project>

--- a/contrib/LibSass.NET.Web/LibSass.NET.Web.csproj
+++ b/contrib/LibSass.NET.Web/LibSass.NET.Web.csproj
@@ -55,15 +55,13 @@
     <None Include="web.config.transform" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent Condition="$(Configuration) == 'Debug'">copy "$(SolutionDir)bin\Debug\libsass.dll" "$(OutputDir)libsass.dll"</PostBuildEvent>
-    <PostBuildEvent Condition="$(Configuration) == 'Release'">copy "$(SolutionDir)bin\libsass.dll" "$(OutputDir)libsass.dll"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+  </Target>
 </Project>

--- a/contrib/LibSass.NET.Web/LibSass.NET.Web.csproj
+++ b/contrib/LibSass.NET.Web/LibSass.NET.Web.csproj
@@ -61,7 +61,7 @@
   </Target>
   -->
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass32.dll" DestinationFiles="$(TargetDir)libsass32.dll" />
-    <Copy SourceFiles="$(SolutionDir)$(OutDir)libsass64.dll" DestinationFiles="$(TargetDir)libsass64.dll" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass32.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="$(SolutionDir)$(OutDir)\libsass64.dll" DestinationFolder="$(TargetDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
Sorry for not creating an issue first, but when I cloned I couldn't get the solution to build because of failing copying of libsass DLLs.
- Use the Release dir instead of plain `bin` when building release
- Use separate object dirs when building the native solutions
- Use the MSBuild Copy task instead of postbuild events
- Update the nuspec with the `$configuration` parameter which was already passing `Release`